### PR TITLE
Fix compilation under msys2-mingw by including missing header

### DIFF
--- a/ritobin_cli/deps/argparse.hpp
+++ b/ritobin_cli/deps/argparse.hpp
@@ -43,6 +43,7 @@ SOFTWARE.
 #include <string_view>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 


### PR DESCRIPTION
+ the std::as_const function requires the `#include <utility>` include,
  which was missing from the ritobin_cli deps library