### PR TITLE
Ensure paths are always converting utf8 <-> utf16 correctly

### DIFF
--- a/res/longpath.manifest
+++ b/res/longpath.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/res/utf8.manifest
+++ b/res/utf8.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+   <assemblyIdentity name="." version="6.0.0.0" />
+   <application>
+      <windowsSettings>
+         <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+      </windowsSettings>
+   </application>
+</assembly>

--- a/ritobin_cli/CMakeLists.txt
+++ b/ritobin_cli/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 
 project(ritobin_cli LANGUAGES CXX)
 

--- a/ritobin_cli/src/main.cpp
+++ b/ritobin_cli/src/main.cpp
@@ -79,7 +79,7 @@ struct Args {
                 .default_value(std::string(""))
                 .help("format of output file");
         program.add_argument("-d", "--dir-hashes")
-                .default_value((fs::path(argv[0]).parent_path() / "hashes").generic_string())
+                .default_value((fs::u8path(argv[0]).parent_path() / "hashes").generic_string())
                 .help("directory containing hashes");
         try {
             program.parse_args(argc, argv);
@@ -119,7 +119,7 @@ struct Args {
             set_binary_mode(file);
         } else {
             if constexpr (M == 'w') {
-                auto parent_dir = fs::path(name).parent_path();
+                auto parent_dir = fs::u8path(name).parent_path();
                 if (std::error_code ec = {}; (fs::create_directories(parent_dir, ec)), ec != std::error_code{}) {
                     throw std::runtime_error("Failed to create parent directory: " + ec.message());
                 }
@@ -191,7 +191,7 @@ struct Args {
             if (input_file == "-") {
                 output_file = "-";
             } else {
-                output_file = fs::path(input_file).replace_extension(format->default_extension()).generic_string();
+                output_file = fs::u8path(input_file).replace_extension(format->default_extension()).generic_string();
                 if (recursive && !output_dir.empty()) {
                     output_file = (output_dir / fs::relative(output_file, input_dir)).generic_string();
                 }

--- a/ritobin_cli/src/main.cpp
+++ b/ritobin_cli/src/main.cpp
@@ -79,7 +79,7 @@ struct Args {
                 .default_value(std::string(""))
                 .help("format of output file");
         program.add_argument("-d", "--dir-hashes")
-                .default_value((fs::u8path(argv[0]).parent_path() / "hashes").generic_string())
+                .default_value((fs::path(argv[0]).parent_path() / "hashes").generic_string())
                 .help("directory containing hashes");
         try {
             program.parse_args(argc, argv);
@@ -119,7 +119,7 @@ struct Args {
             set_binary_mode(file);
         } else {
             if constexpr (M == 'w') {
-                auto parent_dir = fs::u8path(name).parent_path();
+                auto parent_dir = fs::path(name).parent_path();
                 if (std::error_code ec = {}; (fs::create_directories(parent_dir, ec)), ec != std::error_code{}) {
                     throw std::runtime_error("Failed to create parent directory: " + ec.message());
                 }
@@ -191,7 +191,7 @@ struct Args {
             if (input_file == "-") {
                 output_file = "-";
             } else {
-                output_file = fs::u8path(input_file).replace_extension(format->default_extension()).generic_string();
+                output_file = fs::path(input_file).replace_extension(format->default_extension()).generic_string();
                 if (recursive && !output_dir.empty()) {
                     output_file = (output_dir / fs::relative(output_file, input_dir)).generic_string();
                 }

--- a/ritobin_gui/CMakeLists.txt
+++ b/ritobin_gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 
 project(ritobin_gui LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)

--- a/ritobin_lib/CMakeLists.txt
+++ b/ritobin_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 
 project(ritobin_lib LANGUAGES CXX)
 
@@ -31,5 +31,6 @@ add_library(ritobin_lib STATIC
 
 target_include_directories(ritobin_lib PUBLIC src/)
 target_include_directories(ritobin_lib PRIVATE deps/)
-
-
+if (WIN32)
+    target_sources(ritobin_lib INTERFACE ../res/utf8.manifest)
+endif()

--- a/ritobin_lib/CMakeLists.txt
+++ b/ritobin_lib/CMakeLists.txt
@@ -32,5 +32,5 @@ add_library(ritobin_lib STATIC
 target_include_directories(ritobin_lib PUBLIC src/)
 target_include_directories(ritobin_lib PRIVATE deps/)
 if (WIN32)
-    target_sources(ritobin_lib INTERFACE ../res/utf8.manifest)
+    target_sources(ritobin_lib INTERFACE ../res/utf8.manifest ../res/longpath.manifest)
 endif()


### PR DESCRIPTION
This was previously problematic on windows, where native paths are using utf-16 encoding, but file paths may be provided in a different encoding, like utf-8.